### PR TITLE
build with primitive 0.8

### DIFF
--- a/run-st.cabal
+++ b/run-st.cabal
@@ -7,7 +7,7 @@ description:
   data-constructor allocation for the returned value.
   If <https://gitlab.haskell.org/ghc/ghc/issues/15127 issue 15127> is
   resolved, this package will no longer be necessary.
-  
+
 homepage: https://github.com/andrewthad/run-st
 bug-reports: https://github.com/andrewthad/run-st/issues
 license: BSD-3-Clause
@@ -22,7 +22,7 @@ library
   exposed-modules: Control.Monad.ST.Run
   build-depends:
     , base >=4.12 && <5
-    , primitive >=0.7 && <0.8
+    , primitive >=0.7 && <0.9
     , primitive-unlifted >=0.1.1 && <0.2
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=primitive-unlifted:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - run-st-0.1.2.0 (lib) (first run)
Configuring library for run-st-0.1.2.0..
Preprocessing library for run-st-0.1.2.0..
Building library for run-st-0.1.2.0..
[1 of 1] Compiling Control.Monad.ST.Run ( src/Control/Monad/ST/Run.hs, /home/chessai/haskell/run-st/dist-newstyle/build/x86_64-linux/ghc-9.4.4/run-st-0.1.2.0/build/Control/Monad/ST/Run.o, /home/chessai/haskell/run-st/dist-newstyle/build/x86_64-linux/ghc-9.4.4/run-st-0.1.2.0/build/Control/Monad/ST/Run.dyn_o )
```